### PR TITLE
update type of variables

### DIFF
--- a/c2-01-variables.tf
+++ b/c2-01-variables.tf
@@ -101,7 +101,7 @@ variable "fsx_backup_start_time" {
 
 variable "fsx_copy_tags_to_backups" {
   description = "(Optional) A boolean flag indicating whether tags for the file system should be copied to backups. Applicable for `PERSISTENT_1` and `PERSISTENT_2` deployment_type. The default value is false."
-  type        = boolean
+  type        = bool
   default     = false
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Standardized the variable type for `fsx_copy_tags_to_backups` from `boolean` to `bool` in the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->